### PR TITLE
fix launch.json - use `bash` not `sh`

### DIFF
--- a/.config/polybar/launch.sh
+++ b/.config/polybar/launch.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 ## Add this to your wm startup file.
 


### PR DESCRIPTION
your default shell `sh` is likely aliased to `bash`, so the `$UID` variable works, but with `sh` or other shells like `dash` it won't. Explicitly using `bash` fixes it.

```sh
ls -l /bin/sh
```