### PR TITLE
Improve zsh_add_plugin function

### DIFF
--- a/zsh/.config/zsh/zsh-functions
+++ b/zsh/.config/zsh/zsh-functions
@@ -4,14 +4,25 @@ function zsh_add_file() {
 }
 
 function zsh_add_plugin() {
-    PLUGIN_NAME=$(echo $1 | cut -d "/" -f 2)
-    if [ -d "$ZDOTDIR/plugins/$PLUGIN_NAME" ]; then 
-        # For plugins
-        zsh_add_file "plugins/$PLUGIN_NAME/$PLUGIN_NAME.plugin.zsh" || \
-        zsh_add_file "plugins/$PLUGIN_NAME/$PLUGIN_NAME.zsh"
-    else
-        git clone "https://github.com/$1.git" "$ZDOTDIR/plugins/$PLUGIN_NAME"
+    # pretty output
+    local c_reset="\033[0m" c_red="\033[1;31m" c_green="\033[1;32m"
+
+    local PLUGIN_NAME="${1##*\/}"
+    local PLUGIN_DIR="${ZDOTDIR:-$HOME/.config/zsh}/plugins/$PLUGIN_NAME"
+
+    if [ ! -d "$PLUGIN_DIR" ]; then
+        # clone plugin if it does not exists in $PLUGIN_DIR
+        printf "%b==> [zsh-plugin]%b Getting plugin '%s'\n" "$c_green" "$c_reset" "$PLUGIN_NAME"
+
+        git clone --depth 1 --recurse-submodules "https://github.com/${1}.git" "$PLUGIN_DIR" || \
+        { printf "%b==> [zsh-plugin]%b Error getting plugin '%s'\n" "$c_red" "$c_reset" "$PLUGIN_NAME"; return 1; }
     fi
+
+    # at this point, $PLUGIN_DIR will exist (except in
+    # case of network issue), so source the plugin
+    zsh_add_file "plugins/$PLUGIN_NAME/$PLUGIN_NAME.plugin.zsh" || \
+    zsh_add_file "plugins/$PLUGIN_NAME/$PLUGIN_NAME.zsh" || \
+    { printf "%b==> [zsh-plugin]%b Error sourcing plugin '%s' from '%s'\n" "$c_red" "$c_reset" "$PLUGIN_NAME" "$PLUGIN_DIR"; return 1; }
 }
 
 function zsh_add_completion() {


### PR DESCRIPTION
- echo & cut not required
- if a plugin does not exist, it will clone & source it at once and you
  can use the plugin in the running terminal instance. (previous
  implementation required to launch terminal twice to use a plugin if it
  didn't existed)
- pretty output